### PR TITLE
add workaround for missing controller

### DIFF
--- a/app/controllers/partystreusel/styleguide_controller.rb
+++ b/app/controllers/partystreusel/styleguide_controller.rb
@@ -1,5 +1,9 @@
 module Partystreusel
+  class ApplicationController < ActionController::Base
+
+  end
   class StyleguideController < ApplicationController
+    layout 'partystreusel'
     def show
       template = File.join(params[:controller].gsub('partystreusel/',''), params[:page])
       render template

--- a/styleguide/source/layouts/application.html.haml
+++ b/styleguide/source/layouts/application.html.haml
@@ -33,7 +33,7 @@
 
     = csrf_meta_tags
 
-  %body.js-offcanvas{ class: body_class }
+  %body.js-offcanvas
     .offcanvas__outer
       .offcanvas__inner
         %header.page__header{role: "banner"}
@@ -50,7 +50,6 @@
     = render 'layouts/typekit'
 
     -# Application JavaScripts
-    != google_analytics_code
     = javascript_include_tag 'application'#, async: !ScreenConcept.config.assets.debug
 
     <!--[if lte IE 8]>

--- a/styleguide/source/layouts/partystreusel.html.haml
+++ b/styleguide/source/layouts/partystreusel.html.haml
@@ -1,0 +1,1 @@
+application.html.haml


### PR DESCRIPTION
@alexanderadam @kuschti This gets the jasmine specs running again. They were failing because we were loading the new styleguidecontroller that inherited from ApplicationController, but no ApplicationController was around.

I had to explicitly set a layout other than 'application' so the styleguide uses the correct one, so I just made a symlink.

It is getting uglier and uglier.